### PR TITLE
Add endpoint management and macOS build guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,30 @@ export AUDIO_DEVICE="External Microphone"
 uv run local-dictation  # Uses environment settings
 ```
 
+### Building whisper.cpp with Metal/CoreML
+
+For best performance on Apple Silicon, build `whisper.cpp` with Metal and CoreML enabled:
+
+```bash
+cmake -B build -S . \
+  -DGGML_METAL=ON \
+  -DWHISPER_COREML=ON \
+  -DGGML_ACCELERATE=ON
+cmake --build build -j
+```
+
+At runtime, enable the accelerated paths:
+
+```c
+struct whisper_full_params p = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+p.use_gpu = true;          // Metal backend
+p.coreml_encode = true;    // CoreML encoder
+p.no_timestamps = true;    // no token timestamps
+p.temperature = 0.0f;
+```
+
+Greedy sampling or a small beam size (1-2) gives the lowest latency for dictation.
+
 ## Assistant Mode (NEW)
 
 Assistant mode enables voice-controlled text manipulation using on-device MLX language models. When enabled, you can select text and speak commands to process it.

--- a/Settings.json
+++ b/Settings.json
@@ -1,0 +1,6 @@
+{
+  "mode": "ptt",
+  "vad": { "threshold": 0.6, "hangover_ms": 150, "debounce_ms": 200 },
+  "decode_profile": "burst",
+  "hardware": { "metal": true, "coreml_encode": true }
+}

--- a/src/local_dictation/decode_profiles.py
+++ b/src/local_dictation/decode_profiles.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Strategy(Enum):
+    GREEDY = "greedy"
+    BEAM = "beam"
+
+
+@dataclass
+class WhisperParams:
+    use_gpu: bool = True
+    coreml_encode: bool = True
+    no_timestamps: bool = True
+    temperature: float = 0.0
+    strategy: Strategy = Strategy.GREEDY
+    beam_size: int = 1
+
+
+def params_for(profile: str) -> WhisperParams:
+    """Return Whisper parameter presets for a profile."""
+    if profile == "longform":
+        return WhisperParams(
+            use_gpu=True,
+            coreml_encode=True,
+            no_timestamps=False,
+            temperature=0.0,
+            strategy=Strategy.BEAM,
+            beam_size=4,
+        )
+    # default to burst profile
+    return WhisperParams(
+        use_gpu=True,
+        coreml_encode=True,
+        no_timestamps=True,
+        temperature=0.0,
+        strategy=Strategy.GREEDY,
+        beam_size=1,
+    )

--- a/src/local_dictation/dictation_config.py
+++ b/src/local_dictation/dictation_config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass
+class DictationConfig:
+    """Configuration for dictation endpointing and modes."""
+
+    # Modes
+    use_push_to_talk: bool = True
+    use_auto_stop_vad: bool = False
+
+    # VAD tuning (auto-stop mode)
+    vad_frame_ms: int = 20          # 20 ms frames
+    vad_sample_rate: int = 16000
+    vad_hangover_ms: int = 150      # stop after 150 ms of non-speech
+    vad_debounce_ms: int = 200      # ignore re-triggers within 200 ms
+    vad_prob_threshold: float = 0.6 # silero speech prob threshold
+
+    # Push-to-talk
+    ptt_key: str = "shift"          # key name for pynput (e.g. 'shift')

--- a/src/local_dictation/endpoint_manager.py
+++ b/src/local_dictation/endpoint_manager.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import time
+from enum import Enum
+from typing import Optional, Sequence
+
+from .dictation_config import DictationConfig
+
+
+class EndpointDecision(Enum):
+    CONTINUE = 0
+    SHOULD_STOP = 1
+
+
+class EndpointManager:
+    """Endpoint detection manager supporting push-to-talk or VAD auto-stop."""
+
+    class Mode(Enum):
+        PUSH_TO_TALK = "push_to_talk"
+        AUTO_STOP_VAD = "auto_stop_vad"
+
+    def __init__(self, cfg: DictationConfig, vad: Optional[object] = None):
+        self.cfg = cfg
+        self.mode = (self.Mode.PUSH_TO_TALK if cfg.use_push_to_talk
+                     else self.Mode.AUTO_STOP_VAD)
+        self.vad = vad
+        self.last_speech_time: float = 0.0
+        self.last_stop_time: float = 0.0
+        self.is_speech: bool = False
+
+    def on_frame(self, frame: Sequence[float]) -> EndpointDecision:
+        """Process a single 20ms audio frame.
+
+        Args:
+            frame: Sequence of float samples (mono 16 kHz).
+        """
+        if self.mode == self.Mode.PUSH_TO_TALK:
+            return EndpointDecision.CONTINUE
+
+        if self.vad is None:
+            return EndpointDecision.CONTINUE
+
+        p = self.vad.get_speech_prob(frame)
+        now = time.monotonic()
+        if p >= self.cfg.vad_prob_threshold:
+            self.is_speech = True
+            self.last_speech_time = now
+            return EndpointDecision.CONTINUE
+
+        # speech ended? apply hangover + debounce
+        if self.is_speech and (now - self.last_speech_time) * 1000 >= self.cfg.vad_hangover_ms:
+            if (now - self.last_stop_time) * 1000 >= self.cfg.vad_debounce_ms:
+                self.last_stop_time = now
+                self.is_speech = False
+                return EndpointDecision.SHOULD_STOP
+
+        return EndpointDecision.CONTINUE

--- a/src/local_dictation/ptt_controller.py
+++ b/src/local_dictation/ptt_controller.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from pynput import keyboard
+
+from .dictation_config import DictationConfig
+
+
+class PTTController:
+    """Simple push-to-talk controller using pynput."""
+
+    def __init__(self, cfg: DictationConfig,
+                 on_start: Callable[[], None],
+                 on_stop: Callable[[], None]):
+        self.cfg = cfg
+        self._on_start = on_start
+        self._on_stop = on_stop
+        self._is_down = False
+        self._listener = keyboard.Listener(
+            on_press=self._on_press,
+            on_release=self._on_release,
+        )
+
+    def start(self):
+        self._listener.start()
+
+    def stop(self):
+        self._listener.stop()
+
+    def _matches_key(self, key) -> bool:
+        try:
+            return key == getattr(keyboard.Key, self.cfg.ptt_key)
+        except AttributeError:
+            return False
+
+    def _on_press(self, key):
+        if not self._is_down and self._matches_key(key):
+            self._is_down = True
+            self._on_start()
+
+    def _on_release(self, key):
+        if self._is_down and self._matches_key(key):
+            self._is_down = False
+            self._on_stop()


### PR DESCRIPTION
## Summary
- add DictationConfig struct and EndpointManager for push-to-talk or VAD-based endpointing
- provide PTTController and decode profile presets
- document how to build whisper.cpp with Metal and CoreML on macOS

## Testing
- `python -m py_compile src/local_dictation/dictation_config.py src/local_dictation/endpoint_manager.py src/local_dictation/ptt_controller.py src/local_dictation/decode_profiles.py src/local_dictation/audio.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4b060c63c8321819702860779034d